### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM slidewiki/runtime:latest
+FROM node:6-slim
+
+RUN mkdir /nodeApp
+WORKDIR /nodeApp
 
 # add source code
 ADD . /nodeApp
@@ -6,5 +9,5 @@ ADD . /nodeApp
 # package and install tool
 RUN npm pack && npm install -g slidewiki-cli-0.0.1.tgz
 
-#clean up
+# clean up
 RUN rm -rf /nodeApp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM slidewiki/runtime:latest
+
+# add source code
+ADD . /nodeApp
+
+# package and install tool
+RUN npm pack && npm install -g slidewiki-cli-0.0.1.tgz
+
+#clean up
+RUN rm -rf /nodeApp/*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm pack
 $ npm install -g slidewiki-cli-0.0.1.tgz
 ```
 
-To remove it, just 
+To remove it, just
 `$ npm uninstall -g slidewiki-cli`
 
 ## Usage
@@ -33,4 +33,14 @@ Options:
   --user_id      id of the user that will be the owner of the deck copy
   --help         Show help
   --verbose, -v
+```
+
+## Running the tool from Docker image
+
+The tool is also available via the Docker image `slidewiki/cli`. You can use it
+either in interactive mode by starting a shell in the container or you can issue
+a command from the command line like this:
+
+```
+docker run -it --rm slidewiki/cli slidewiki --help
 ```


### PR DESCRIPTION
This change adds a Dockerfile that wrapps the tool into a Docker image based on the SlideWiki runtime image. README was updated with an example on how to call the tool via Docker image.